### PR TITLE
play airspace alarm on CAI-302 vario

### DIFF
--- a/src/Blackboard/DeviceBlackboard.cpp
+++ b/src/Blackboard/DeviceBlackboard.cpp
@@ -304,3 +304,10 @@ DeviceBlackboard::SetStandbyFrequency(RadioFrequency frequency,
   if (devices != nullptr)
     devices->PutStandbyFrequency(frequency, name, env);
 }
+
+void
+DeviceBlackboard::PlayAlarm(OperationEnvironment &env)
+{
+  if (devices != nullptr)
+    devices->PlayAlarm(env);
+}

--- a/src/Blackboard/DeviceBlackboard.hpp
+++ b/src/Blackboard/DeviceBlackboard.hpp
@@ -148,6 +148,7 @@ public:
   void SetStandbyFrequency(RadioFrequency frequency,
                            const TCHAR *name,
                            OperationEnvironment &env);
+  void PlayAlarm(OperationEnvironment &env);
 
   /**
    * Check the expiry time of the device connection with the wall

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -226,6 +226,7 @@ DeviceConfig::Clear()
   enabled = true;
   sync_from_device = true;
   sync_to_device = true;
+  play_alarms = true;
   k6bt = false;
 #ifndef NDEBUG
   dump_port = false;

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -231,6 +231,11 @@ struct DeviceConfig {
   bool sync_from_device;
 
   /**
+   * Should XCSoar play sound alarms using the device
+   */
+  bool play_alarms;
+
+  /**
    * Does this port type use a baud rate?
    */
   static bool UsesSpeed(PortType port_type) {

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -931,6 +931,22 @@ DeviceDescriptor::PutQNH(const AtmosphericPressure &value,
   return true;
 }
 
+bool
+DeviceDescriptor::PlayAlarm(OperationEnvironment &env)
+{
+  assert(InMainThread());
+
+  if (device == nullptr || !config.play_alarms)
+    return true;
+
+  if (!Borrow())
+    /* TODO: postpone until the borrowed device has been returned */
+    return false;
+  ScopeReturnDevice restore(*this, env);
+
+  return device->PlayAlarm(env);
+}
+
 static bool
 DeclareToFLARM(const struct Declaration &declaration, Port &port,
                const Waypoint *home, OperationEnvironment &env)

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -480,6 +480,7 @@ public:
                            const TCHAR *name,
                            OperationEnvironment &env);
   bool PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env);
+  bool PlayAlarm(OperationEnvironment &env);
 
   /**
    * Caller is responsible for calling Borrow() and Return().

--- a/src/Device/Driver.cpp
+++ b/src/Device/Driver.cpp
@@ -63,6 +63,12 @@ AbstractDevice::PutBallast(fixed fraction, fixed overload,
 }
 
 bool
+AbstractDevice::PlayAlarm(OperationEnvironment &env)
+{
+  return true;
+}
+
+bool
 AbstractDevice::PutQNH(const AtmosphericPressure &pres,
                        OperationEnvironment &env)
 {

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -144,6 +144,11 @@ public:
                                    OperationEnvironment &env) = 0;
 
   /**
+   * Play alarm sound on the device (vario).
+   */
+  virtual bool PlayAlarm(OperationEnvironment &env) = 0;
+
+  /**
    * Enable pass-through mode.  This may be used to communicate
    * directly with the device that is "behind" this one (e.g. a LX1600
    * connected to a FLARM).
@@ -252,6 +257,7 @@ public:
   bool PutStandbyFrequency(RadioFrequency frequency,
                            const TCHAR *name,
                            OperationEnvironment &env) override;
+  bool PlayAlarm(OperationEnvironment &env) override;
 
   bool EnablePassThrough(OperationEnvironment &env) override;
 
@@ -341,6 +347,11 @@ struct DeviceRegister {
      * EnablePassThrough() is implemented.
      */
     PASS_THROUGH = 0x200,
+
+    /**
+     * Is this driver capable of playing alarm sounds?
+     */
+    PLAY_ALARMS = 0x400,
   };
 
   /**
@@ -378,6 +389,10 @@ struct DeviceRegister {
    */
   bool CanSendSettings() const {
     return (flags & SEND_SETTINGS) != 0;
+  }
+
+  bool CanPlayAlarms() const {
+    return (flags & PLAY_ALARMS) != 0;
   }
 
   /**

--- a/src/Device/Driver/CAI302/Internal.hpp
+++ b/src/Device/Driver/CAI302/Internal.hpp
@@ -69,6 +69,8 @@ public:
   virtual bool PutBallast(fixed fraction, fixed overload,
                           OperationEnvironment &env) override;
 
+  virtual bool PlayAlarm(OperationEnvironment &env) override;
+
   virtual bool Declare(const Declaration &declaration, const Waypoint *home,
                        OperationEnvironment &env) override;
 

--- a/src/Device/Driver/CAI302/PocketNav.cpp
+++ b/src/Device/Driver/CAI302/PocketNav.cpp
@@ -56,3 +56,12 @@ CAI302::PutBallast(Port &port, fixed fraction, OperationEnvironment &env)
   sprintf(buffer, "!g,b%u\r", ballast);
   return port.Write(buffer);
 }
+
+bool
+CAI302::PlayAlarm(Port &port, OperationEnvironment &env)
+{
+  unsigned beep_type = 0;
+  char buffer[32];
+  sprintf(buffer, "!c,%u,255,0\r", beep_type);
+  return port.Write(buffer);
+}

--- a/src/Device/Driver/CAI302/PocketNav.hpp
+++ b/src/Device/Driver/CAI302/PocketNav.hpp
@@ -33,6 +33,7 @@ namespace CAI302 {
   bool PutMacCready(Port &port, fixed mc, OperationEnvironment &env);
   bool PutBugs(Port &port, fixed bugs, OperationEnvironment &env);
   bool PutBallast(Port &port, fixed fraction, OperationEnvironment &env);
+  bool PlayAlarm(Port &port, OperationEnvironment &env);
 }
 
 #endif

--- a/src/Device/Driver/CAI302/Register.cpp
+++ b/src/Device/Driver/CAI302/Register.cpp
@@ -35,6 +35,7 @@ const struct DeviceRegister cai302_driver = {
   _T("Cambridge CAI302"),
   DeviceRegister::BULK_BAUD_RATE |
   DeviceRegister::DECLARE | DeviceRegister::LOGGER | DeviceRegister::MANAGE |
-  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS |
+  DeviceRegister::PLAY_ALARMS,
   CAI302CreateOnPort,
 };

--- a/src/Device/Driver/CAI302/Settings.cpp
+++ b/src/Device/Driver/CAI302/Settings.cpp
@@ -42,3 +42,9 @@ CAI302Device::PutBallast(fixed fraction, gcc_unused fixed overload,
 {
   return CAI302::PutBallast(port, fraction, env);
 }
+
+bool
+CAI302Device::PlayAlarm(OperationEnvironment &env)
+{
+  return CAI302::PlayAlarm(port, env);
+}

--- a/src/Device/MultipleDevices.cpp
+++ b/src/Device/MultipleDevices.cpp
@@ -88,6 +88,12 @@ MultipleDevices::PutVolume(unsigned volume, OperationEnvironment &env)
     i->PutVolume(volume, env);
 }
 
+void MultipleDevices::PlayAlarm(OperationEnvironment &env)
+{
+  for (DeviceDescriptor *i : devices)
+    i->PlayAlarm(env);
+}
+
 void
 MultipleDevices::PutActiveFrequency(RadioFrequency frequency,
                                     const TCHAR *name,

--- a/src/Device/MultipleDevices.hpp
+++ b/src/Device/MultipleDevices.hpp
@@ -90,6 +90,7 @@ public:
   void PutStandbyFrequency(RadioFrequency frequency, const TCHAR *name,
                            OperationEnvironment &env);
   void PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env);
+  void PlayAlarm(OperationEnvironment &env);
   void NotifySensorUpdate(const MoreData &basic);
   void NotifyCalculatedUpdate(const MoreData &basic,
                               const DerivedInfo &calculated);

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -28,6 +28,7 @@ Copyright_License {
 #include "Audio/Sound.hpp"
 #include "Dialogs/Airspace/AirspaceWarningDialog.hpp"
 #include "Event/Idle.hpp"
+#include "Operation/Operation.hpp"
 #include "PageActions.hpp"
 #include "Widget/QuestionWidget.hpp"
 #include "Form/ActionListener.hpp"
@@ -37,6 +38,7 @@ Copyright_License {
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "Blackboard/DeviceBlackboard.hpp"
 
 class AirspaceWarningWidget final
   : public QuestionWidget, private ActionListener {
@@ -226,6 +228,8 @@ AirspaceWarningMonitor::alarmSet() {
   if (!alarm_active) {
     last_alarm_time = CommonInterface::Calculated().date_time_local;
     PlayResource(_T("IDR_WAV_AIRSPACE"));
+    NullOperationEnvironment env;
+    device_blackboard->PlayAlarm(env);
   }
   alarm_active = true;
 }
@@ -247,6 +251,8 @@ AirspaceWarningMonitor::replayAlarmSound(ProtectedAirspaceWarningManager &airspa
         if (seconds_since_last_alarm > 0  && ((unsigned)seconds_since_last_alarm) >= sound_interval) {
           /* repetitive alarm sound */
           PlayResource(_T("IDR_WAV_AIRSPACE"));
+          NullOperationEnvironment env;
+          device_blackboard->PlayAlarm(env);
           last_alarm_time = current_time;
         }
       }

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -190,6 +190,9 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
   MakeDeviceSettingName(buffer, "Port", n, "SyncToDevice");
   map.Get(buffer, config.sync_to_device);
 
+  MakeDeviceSettingName(buffer, "Port", n, "PlayAlarms");
+  map.Get(buffer, config.play_alarms);
+
   MakeDeviceSettingName(buffer, "Port", n, "K6Bt");
   map.Get(buffer, config.k6bt);
 
@@ -277,6 +280,9 @@ Profile::SetDeviceConfig(ProfileMap &map,
 
   MakeDeviceSettingName(buffer, "Port", n, "SyncToDevice");
   map.Set(buffer, config.sync_to_device);
+
+  MakeDeviceSettingName(buffer, "Port", n, "PlayAlarms");
+  map.Set(buffer, config.play_alarms);
 
   MakeDeviceSettingName(buffer, "Port", n, "K6Bt");
   map.Set(buffer, config.k6bt);


### PR DESCRIPTION
New feature added. With this modification it is possible to play sound alarms using external vario (CAI-302). Some other variometers (gofly-project-v4) are also able to play sound alarms.
