### PR TITLE
Adjust URL for android/ioio submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "android/ioio"]
 	path = android/ioio
-	url = git://git.xcsoar.org/xcsoar/master/ioio.git
+	url = git://github.com/xcsoar/ioio
 [submodule "kobo/uimage"]
 	path = kobo/uimage
 	url = https://github.com/ifly7charlie/XCSoar-Kobo-Build

--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -41,6 +41,14 @@ KOBO_MENU_SOURCES = \
 	$(SRC)/Profile/ProfileMap.cpp \
 	$(SRC)/Profile/Map.cpp \
 	$(SRC)/Profile/Current.cpp \
+	$(SRC)/Profile/File.cpp \
+	$(SRC)/Profile/NumericValue.cpp \
+	$(SRC)/Profile/StringValue.cpp \
+	$(SRC)/LogFile.cpp \
+	$(SRC)/Profile/PathValue.cpp \
+	$(SRC)/Time/BrokenDateTime.cpp \
+	$(SRC)/Time/BrokenTime.cpp \
+	$(SRC)/Formatter/TimeFormatter.cpp \
 	$(SRC)/Kobo/KoboMenu.cpp
 KOBO_MENU_LDADD = $(FAKE_LIBS)
 KOBO_MENU_DEPENDS = WIDGET FORM SCREEN EVENT RESOURCE IO ASYNC LIBNET OS THREAD MATH UTIL

--- a/build/warnings.mk
+++ b/build/warnings.mk
@@ -9,13 +9,13 @@ CXXFLAGS += -Wmissing-noreturn
 
 # disable some warnings, we're not ready for them yet
 CXXFLAGS += -Wno-unused-parameter
-CXXFLAGS += -Wno-missing-field-initializers 
+CXXFLAGS += -Wno-missing-field-initializers -Wno-error=shift-negative-value
 CXXFLAGS += -Wcast-align
 
 # plain C warnings
 
 CFLAGS += $(WARNINGS)
-CFLAGS += -Wmissing-prototypes -Wstrict-prototypes
+CFLAGS += -Wmissing-prototypes -Wstrict-prototypes -Wno-error=shift-negative-value
 CFLAGS += -Wnested-externs
 
 # make warnings fatal (for perfectionists)

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -184,7 +184,7 @@ CreateFirstWidget(AlternatesListHeaderWidget &listener, const DerivedInfo& calcu
 {
   if (calculated.common_stats.has_non_airfield_landables)
         return new CheckBoxWidget(UIGlobals::GetDialogLook(), _("Airports only"), listener, AlternatesListHeaderWidget::AirFieldsOnly);
-        return new TextWidget();
+  return new TextWidget();
 }
 
 AlternatesListHeaderWidget::AlternatesListHeaderWidget(const DerivedInfo& _calculated)

--- a/src/Form/HorizontalList.cpp
+++ b/src/Form/HorizontalList.cpp
@@ -544,7 +544,7 @@ HorizontalListControl::ScrollAdvance(bool forward)
   if (!HasDraggableScreen())
     return false;
 
-    unsigned old_item = GetItemFromPixelOrigin(GetPixelOrigin());
+  unsigned old_item = GetItemFromPixelOrigin(GetPixelOrigin());
   if ((forward && (old_item >= (GetLength() - 1))) ||
       (!forward && old_item == 0))
     return false;


### PR DESCRIPTION
Please see https://github.com/XCSoar/XCSoar/pull/65/files - tophat need the same change
Some compilation warnings are ignored to fix build
And it seems that KoboMenu dependencies are missing

FYI I'm trying to https://github.com/lordfolken/xcsoar-docker-build for building tophat for kobo. Now application build is fine kobo kernel compilation will be next.
