### PR TITLE
freetype-2.6.tar.bz2 is no longer kept.

### DIFF
--- a/kobo/build.py
+++ b/kobo/build.py
@@ -241,8 +241,8 @@ thirdparty_libs = [
     ),
 
     FreeTypeProject(
-        'http://download.savannah.gnu.org/releases/freetype/freetype-2.6.tar.bz2',
-        '5682890cb0267f6671dd3de6eabd3e69',
+        'https://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.bz2',
+        'b3230110e0cab777e0df7631837ac36e',
         'lib/libfreetype.a',
         [
             '--disable-shared', '--enable-static',


### PR DESCRIPTION
title says all.