### PR TITLE
Update NOAADownloader.cpp

### DIFF
--- a/src/Weather/NOAADownloader.cpp
+++ b/src/Weather/NOAADownloader.cpp
@@ -152,7 +152,7 @@ NOAADownloader::DownloadMETAR(const char *code, METAR &metar,
 #endif
 
   // Build file url
-  char url[256] = "http://tgftp.nws.noaa.gov/data/observations/metar/decoded/";
+  char url[256] = "https://tgftp.nws.noaa.gov/data/observations/metar/decoded/";
   strcat(url, code);
   strcat(url, ".TXT");
 
@@ -247,7 +247,7 @@ NOAADownloader::DownloadTAF(const char *code, TAF &taf,
 #endif
 
   // Build file url
-  char url[256] = "http://tgftp.nws.noaa.gov/data/forecasts/taf/stations/";
+  char url[256] = "https://tgftp.nws.noaa.gov/data/forecasts/taf/stations/";
   strcat(url, code);
   strcat(url, ".TXT");
 


### PR DESCRIPTION
Adjust URLs with https for downloading METAR/TAF infos. Fixes again TH-732 